### PR TITLE
Deg 15 스탯 관리

### DIFF
--- a/.idea/.idea.Degulleo3D/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/.idea.Degulleo3D/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="CssInvalidPropertyValue" enabled="true" level="ERROR" enabled_by_default="true" />
+  </profile>
+</component>

--- a/Assets/Editor.meta
+++ b/Assets/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fb977eee32cc2024181234437bfb8480
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/ReadOnlyDrawer.cs
+++ b/Assets/Editor/ReadOnlyDrawer.cs
@@ -1,0 +1,24 @@
+#if UNITY_EDITOR
+using UnityEngine;
+using UnityEditor;
+
+// PlayerStatsTest.ReadOnlyAttribute를 위한 에디터 속성 드로어
+[CustomPropertyDrawer(typeof(PlayerStatsTest.ReadOnlyAttribute))]
+public class ReadOnlyDrawer : PropertyDrawer
+{
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        // 이전 GUI 활성화 상태 저장
+        bool wasEnabled = GUI.enabled;
+        
+        // 필드 비활성화 (읽기 전용)
+        GUI.enabled = false;
+        
+        // 속성 그리기
+        EditorGUI.PropertyField(position, property, label, true);
+        
+        // GUI 활성화 상태 복원
+        GUI.enabled = wasEnabled;
+    }
+}
+#endif

--- a/Assets/Editor/ReadOnlyDrawer.cs.meta
+++ b/Assets/Editor/ReadOnlyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb5079b7064e2324890f78e18dfe7a6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KSH.meta
+++ b/Assets/KSH.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8899b70334c78204fb97b6da706ac4c6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KSH/GameConstants.cs
+++ b/Assets/KSH/GameConstants.cs
@@ -2,9 +2,38 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-
-
-public class GameConstants : MonoBehaviour
+// 행동 타입
+public enum ActionType
 {
+    NotSleep, // 5시간 미만 취침
+    LessSleep, // 5시간 취침
+    SleepWell, // 8시간 취침
+    ForcedSleep, // 강제 수면(10시간)
+    Eat,
+    Work, 
+    Dungeon,
+    // 보너스 스테이지 제외
+    Housework, // 집안일
+    OvertimeWork, // 야근
+    TeamDinner, // 회식
+    Absence // 결근
+}
+
+public class GameConstants
+{
+    // 기본 스탯 값
+    public float baseHealth = 8f;
+    public float baseTime = 8f;
+    public float baseReputation = 5f;
     
+    // 스탯 한계 값
+    public float maxHealth = 10f;
+    public float maxTime = 24f;
+    public float maxReputation = 10f;
+    
+    // 강제 값
+    public float forcedValue = 999f;
+    
+    // 날짜 한계 값
+    public static int maxDays = 7;
 }

--- a/Assets/KSH/GameConstants.cs
+++ b/Assets/KSH/GameConstants.cs
@@ -1,0 +1,10 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+
+public class GameConstants : MonoBehaviour
+{
+    
+}

--- a/Assets/KSH/GameConstants.cs.meta
+++ b/Assets/KSH/GameConstants.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e1682026c3858a4f8974675387aaf5a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KSH/GameManager.cs
+++ b/Assets/KSH/GameManager.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class GameManager : Singleton<GameManager>
+{
+    private Canvas _canvas;
+    
+    public void ChangeToGameScene()
+    {
+        SceneManager.LoadScene("Game"); // 던전 Scene
+    }
+    
+    public void ChangeToMainScene()
+    {
+        SceneManager.LoadScene("Housing"); // Home Scene
+    }
+    
+    // ToDo: Open Setting Panel 등 Panel 처리
+    
+    protected override void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        // ToDo: 씬 로드 시 동작 구현. ex: BGM 변경
+        
+        // UI용 Canvas 찾기
+        // _canvas = GameObject.FindObjectOfType<Canvas>();
+    }
+    
+    private void OnApplicationQuit()
+    {
+        // TODO: 게임 종료 시 로직 추가
+    }
+}

--- a/Assets/KSH/GameManager.cs
+++ b/Assets/KSH/GameManager.cs
@@ -72,6 +72,14 @@ public class GameManager : Singleton<GameManager>
         // _canvas = GameObject.FindObjectOfType<Canvas>();
     }
     
+    private void OnDestroy()
+    {
+        if (playerStats != null)
+        {
+            playerStats.OnDayEnded -= AdvanceDay; // 이벤트 구독 해제
+        }
+    }
+    
     private void OnApplicationQuit()
     {
         // TODO: 게임 종료 시 로직 추가

--- a/Assets/KSH/GameManager.cs
+++ b/Assets/KSH/GameManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -5,7 +6,51 @@ using UnityEngine.SceneManagement;
 
 public class GameManager : Singleton<GameManager>
 {
+    [SerializeField] private PlayerStats playerStats;
+    
     private Canvas _canvas;
+    
+    // 게임 진행 상태
+    private int currentDay = 1;
+    public int CurrentDay => currentDay;
+    private int maxDays = GameConstants.maxDays;
+    
+    // 날짜 변경 이벤트
+    public event Action<int> OnDayChanged;
+    
+    private void Start()
+    {
+        // PlayerStats의 하루 종료 이벤트 구독
+        if (playerStats == null)
+        {
+            playerStats = FindObjectOfType<PlayerStats>();
+            if (playerStats == null)
+            {
+                Debug.LogError("PlayerStats 컴포넌트를 찾을 수 없습니다. 함께 추가해주세요.");
+            }
+        }
+        playerStats.OnDayEnded += AdvanceDay;
+    }
+    
+    // 날짜 진행
+    public void AdvanceDay()
+    {
+        currentDay++;
+        OnDayChanged?.Invoke(currentDay);
+        
+        // 최대 일수 도달 체크
+        if (currentDay > maxDays)
+        {
+            TriggerTimeEnding();
+        }
+    }
+    
+    // 엔딩 트리거
+    private void TriggerTimeEnding()
+    {
+        // TODO: 엔딩 처리 로직
+        Debug.Log("7일이 지나 게임이 종료됩니다.");
+    }
     
     public void ChangeToGameScene()
     {
@@ -17,11 +62,11 @@ public class GameManager : Singleton<GameManager>
         SceneManager.LoadScene("Housing"); // Home Scene
     }
     
-    // ToDo: Open Setting Panel 등 Panel 처리
+    // TODO: Open Setting Panel 등 Panel 처리
     
     protected override void OnSceneLoaded(Scene scene, LoadSceneMode mode)
     {
-        // ToDo: 씬 로드 시 동작 구현. ex: BGM 변경
+        // TODO: 씬 로드 시 동작 구현. ex: BGM 변경
         
         // UI용 Canvas 찾기
         // _canvas = GameObject.FindObjectOfType<Canvas>();

--- a/Assets/KSH/GameManager.cs
+++ b/Assets/KSH/GameManager.cs
@@ -27,6 +27,7 @@ public class GameManager : Singleton<GameManager>
             if (playerStats == null)
             {
                 Debug.LogError("PlayerStats 컴포넌트를 찾을 수 없습니다. 함께 추가해주세요.");
+                return;
             }
         }
         playerStats.OnDayEnded += AdvanceDay;

--- a/Assets/KSH/GameManager.cs.meta
+++ b/Assets/KSH/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 450038edae05f9b4d94ff56c62444048
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KSH/PlayerStats.cs
+++ b/Assets/KSH/PlayerStats.cs
@@ -1,0 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerStats : MonoBehaviour
+{
+    
+}

--- a/Assets/KSH/PlayerStats.cs
+++ b/Assets/KSH/PlayerStats.cs
@@ -8,9 +8,9 @@ public class PlayerStats : MonoBehaviour
     private GameConstants _gameConstants;
     private ValueByAction _valueByAction;
     
-    public float Time { get; private set; }
-    public float Health { get; private set; }
-    public float Reputation { get; private set; }
+    public float TimeStat { get; private set; }
+    public float HealthStat { get; private set; }
+    public float ReputationStat { get; private set; }
     
     public event Action OnDayEnded;
     
@@ -20,9 +20,24 @@ public class PlayerStats : MonoBehaviour
         _valueByAction = new ValueByAction();
         _valueByAction.Initialize(); // 값 초기화
         
-        Health = _gameConstants.baseHealth;
-        Time = _gameConstants.baseTime;
-        Reputation = _gameConstants.baseReputation;
+        HealthStat = _gameConstants.baseHealth;
+        TimeStat = _gameConstants.baseTime;
+        ReputationStat = _gameConstants.baseReputation;
+    }
+
+    // 현재 체력으로 해당 행동이 가능한 지 확인
+    public bool canPerformByHealth(ActionType actionType)
+    {
+        ActionEffect effect = _valueByAction.GetActionEffect(actionType);
+
+        if (HealthStat >= effect.healthChange)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
     }
     
     // 행동 처리 메서드
@@ -46,20 +61,20 @@ public class PlayerStats : MonoBehaviour
         // 시간 리셋
         if (isForced)
         {
-            Time = _gameConstants.baseTime; // 강제 수면일 시 아침 8시 기상 고정
+            TimeStat = _gameConstants.baseTime; // 강제 수면일 시 아침 8시 기상 고정
         }
         else
         {
-            Time -= _gameConstants.maxTime; 
+            TimeStat -= _gameConstants.maxTime; 
         }
     }
     
     // 행동에 따른 내부 스탯 변경 메서드
     public void ModifyTime(float time)
     {
-        Time += time;
+        TimeStat += time;
 
-        if (Time >= _gameConstants.maxTime)
+        if (TimeStat >= _gameConstants.maxTime)
         {
             if (time == _gameConstants.forcedValue)
             {
@@ -74,21 +89,32 @@ public class PlayerStats : MonoBehaviour
     
     public void ModifyHealth(float health)
     {
-        Health += health;
-
-        if (Health > _gameConstants.maxHealth)
+        HealthStat += health;
+        
+        // 혹시 모를 음수 값 처리
+        if (HealthStat < 0)
         {
-            Health = _gameConstants.maxHealth;
+            HealthStat = 0.0f;
+        }
+
+        if (HealthStat > _gameConstants.maxHealth)
+        {
+            HealthStat = _gameConstants.maxHealth;
         }
     }
 
     public void ModifyReputation(float reputation)
     {
-        Reputation += reputation;
+        ReputationStat += reputation;
 
-        if (Reputation > _gameConstants.maxReputation)
+        if (ReputationStat < 0)
         {
-            Reputation = _gameConstants.maxReputation;
+            ReputationStat = 0.0f;
+        }
+
+        if (ReputationStat > _gameConstants.maxReputation)
+        {
+            ReputationStat = _gameConstants.maxReputation;
         }
     }
 }

--- a/Assets/KSH/PlayerStats.cs
+++ b/Assets/KSH/PlayerStats.cs
@@ -26,7 +26,7 @@ public class PlayerStats : MonoBehaviour
     }
 
     // 현재 체력으로 해당 행동이 가능한 지 확인
-    public bool canPerformByHealth(ActionType actionType)
+    public bool CanPerformByHealth(ActionType actionType)
     {
         ActionEffect effect = _valueByAction.GetActionEffect(actionType);
 

--- a/Assets/KSH/PlayerStats.cs
+++ b/Assets/KSH/PlayerStats.cs
@@ -1,8 +1,94 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
 public class PlayerStats : MonoBehaviour
 {
+    private GameConstants _gameConstants;
+    private ValueByAction _valueByAction;
     
+    public float Time { get; private set; }
+    public float Health { get; private set; }
+    public float Reputation { get; private set; }
+    
+    public event Action OnDayEnded;
+    
+    private void Start()
+    {
+        _gameConstants = new GameConstants();
+        _valueByAction = new ValueByAction();
+        _valueByAction.Initialize(); // 값 초기화
+        
+        Health = _gameConstants.baseHealth;
+        Time = _gameConstants.baseTime;
+        Reputation = _gameConstants.baseReputation;
+    }
+    
+    // 행동 처리 메서드
+    public void PerformAction(ActionType actionType)
+    {
+        // 액션에 따른 스탯 소모 값 가져오기
+        ActionEffect effect = _valueByAction.GetActionEffect(actionType);
+    
+        // 스탯 변경 적용
+        ModifyTime(effect.timeChange);
+        ModifyHealth(effect.healthChange);
+        ModifyReputation(effect.reputationChange);
+    }
+    
+    // 하루 종료 처리
+    private void EndDay(bool isForced) //bool isForced? 해서 true면 강제 수면이라 8시에 깨는
+    {
+        // 하루 종료 이벤트 발생
+        OnDayEnded?.Invoke();
+        
+        // 시간 리셋
+        if (isForced)
+        {
+            Time = _gameConstants.baseTime; // 강제 수면일 시 아침 8시 기상 고정
+        }
+        else
+        {
+            Time -= _gameConstants.maxTime; 
+        }
+    }
+    
+    // 행동에 따른 내부 스탯 변경 메서드
+    public void ModifyTime(float time)
+    {
+        Time += time;
+
+        if (Time >= _gameConstants.maxTime)
+        {
+            if (time == _gameConstants.forcedValue)
+            {
+                EndDay(true);
+            }
+            else
+            {
+                EndDay(false);
+            }
+        }
+    }
+    
+    public void ModifyHealth(float health)
+    {
+        Health += health;
+
+        if (Health > _gameConstants.maxHealth)
+        {
+            Health = _gameConstants.maxHealth;
+        }
+    }
+
+    public void ModifyReputation(float reputation)
+    {
+        Reputation += reputation;
+
+        if (Reputation > _gameConstants.maxReputation)
+        {
+            Reputation = _gameConstants.maxReputation;
+        }
+    }
 }

--- a/Assets/KSH/PlayerStats.cs.meta
+++ b/Assets/KSH/PlayerStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8bccfaf46267e2544aa4bae52756f182
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KSH/Singleton.cs
+++ b/Assets/KSH/Singleton.cs
@@ -1,0 +1,45 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public abstract class Singleton<T> : MonoBehaviour where T : Component
+{
+    private static T _instance;
+
+    public static T Instance
+    {
+        get
+        {
+            if (_instance == null)
+            {
+                _instance = FindObjectOfType<T>();
+                if (_instance == null)
+                {
+                    GameObject obj = new GameObject();
+                    obj.name = typeof(T).Name;
+                    _instance = obj.AddComponent<T>();
+                }
+            }
+            return _instance;
+        }
+    }
+
+    void Awake()
+    {
+        if (_instance == null)
+        {
+            _instance = this as T;
+            DontDestroyOnLoad(gameObject); // obj가 destory 안되도록 설정
+            
+            // 씬 전환시 호출되는 액션 메서드 할당
+            SceneManager.sceneLoaded += OnSceneLoaded;
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    protected abstract void OnSceneLoaded(Scene scene, LoadSceneMode mode);
+}

--- a/Assets/KSH/Singleton.cs.meta
+++ b/Assets/KSH/Singleton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 014fe0082bc24a041a78cce62ba16b5d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KSH/TestCode.meta
+++ b/Assets/KSH/TestCode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 533241c82a79dcc46932391bf865ce21
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KSH/TestCode/PlayerStatsTest.cs
+++ b/Assets/KSH/TestCode/PlayerStatsTest.cs
@@ -1,0 +1,103 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerStatsTest : MonoBehaviour
+{
+    [Header("현재 스탯")]
+    [SerializeField, ReadOnly] private float currentTime;
+    [SerializeField, ReadOnly] private float currentHealth;
+    [SerializeField, ReadOnly] private float currentReputation;
+    [SerializeField, ReadOnly] private int currentDay;
+
+    [Header("테스트 액션")]
+    [Tooltip("액션을 선택하고 체크박스를 체크하여 실행")]
+    [SerializeField] private ActionType actionToTest;
+    [SerializeField] private bool executeAction;
+
+    // 컴포넌트 참조
+    [Header("필수 참조")]
+    [SerializeField] private PlayerStats playerStats;
+    [SerializeField] private GameManager gameManager;
+
+    // ReadOnly 속성 (인스펙터에서 수정 불가능하게 만듦)
+    public class ReadOnlyAttribute : PropertyAttribute { }
+
+    private void Start()
+    {
+        // 참조 찾기 (없을 경우)
+        if (playerStats == null)
+        {
+            playerStats = FindObjectOfType<PlayerStats>();
+            Debug.Log("PlayerStats를 찾아 참조했습니다.");
+        }
+        
+        if (gameManager == null)
+        {
+            gameManager = FindObjectOfType<GameManager>();
+            Debug.Log("GameManager를 찾아 참조했습니다.");
+        }
+        
+        // 초기 스탯 표시 업데이트
+        UpdateStatsDisplay();
+    }
+
+    private void Update()
+    {
+        if (Application.isPlaying)
+        {
+            // 매 프레임마다 스탯 업데이트
+            UpdateStatsDisplay();
+            
+            // 체크박스가 체크되면 선택된 액션 실행
+            if (executeAction)
+            {
+                ExecuteSelectedAction();
+                executeAction = false; // 체크박스 초기화
+            }
+        }
+    }
+    
+    private void UpdateStatsDisplay()
+    {
+        // 참조 확인 후 스탯 업데이트
+        if (playerStats != null)
+        {
+            currentTime = playerStats.Time;
+            currentHealth = playerStats.Health;
+            currentReputation = playerStats.Reputation;
+            
+            // GameManager에서 날짜 정보 가져오기
+            if (gameManager != null)
+            {
+                currentDay = gameManager.CurrentDay;
+            }
+            else
+            {
+                Debug.LogWarning("GameManager 참조가 없습니다.");
+            }
+        }
+        else
+        {
+            Debug.LogWarning("PlayerStats 참조가 없습니다.");
+        }
+    }
+    
+    private void ExecuteSelectedAction()
+    {
+        if (playerStats != null)
+        {
+            // 선택한 액션 실행
+            playerStats.PerformAction(actionToTest);
+            UpdateStatsDisplay();
+            Debug.Log($"액션 실행: {actionToTest}");
+            
+            // 콘솔에 현재 스탯 정보 출력
+            Debug.Log($"현재 스탯 - 시간: {currentTime}, 체력: {currentHealth}, 평판: {currentReputation}, 날짜: {currentDay}");
+        }
+        else
+        {
+            Debug.LogError("PlayerStats 참조가 없어 액션을 실행할 수 없습니다.");
+        }
+    }
+}

--- a/Assets/KSH/TestCode/PlayerStatsTest.cs
+++ b/Assets/KSH/TestCode/PlayerStatsTest.cs
@@ -63,9 +63,9 @@ public class PlayerStatsTest : MonoBehaviour
         // 참조 확인 후 스탯 업데이트
         if (playerStats != null)
         {
-            currentTime = playerStats.Time;
-            currentHealth = playerStats.Health;
-            currentReputation = playerStats.Reputation;
+            currentTime = playerStats.TimeStat;
+            currentHealth = playerStats.HealthStat;
+            currentReputation = playerStats.ReputationStat;
             
             // GameManager에서 날짜 정보 가져오기
             if (gameManager != null)

--- a/Assets/KSH/TestCode/PlayerStatsTest.cs.meta
+++ b/Assets/KSH/TestCode/PlayerStatsTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae7f2b39529d58a4fa75cf1d30dae9be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KSH/TestCode/Test.prefab
+++ b/Assets/KSH/TestCode/Test.prefab
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a65e9dd60a7532ae1c4c43fda477ac0940c18c5c60f8a164b6fd52b9f1f4a42
+size 5196

--- a/Assets/KSH/TestCode/Test.prefab.meta
+++ b/Assets/KSH/TestCode/Test.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 90448f678f8c503408de14c38cd7c653
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KSH/ValueByAction.cs
+++ b/Assets/KSH/ValueByAction.cs
@@ -1,0 +1,61 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+// 각 액션이 스탯에 미치는 영향을 담는 간단한 구조체
+public struct ActionEffect
+{
+    public float timeChange;
+    public float healthChange;
+    public float reputationChange;
+
+    public ActionEffect(float time, float health, float reputation)
+    {
+        timeChange = time;
+        healthChange = health;
+        reputationChange = reputation;
+    }
+}
+
+public class ValueByAction
+{
+    private GameConstants _gameConstants;
+    private Dictionary<ActionType, ActionEffect> actionEffects;
+
+    public void Initialize()
+    {
+        _gameConstants = new GameConstants();
+        InitializeActionEffects();
+    }
+
+    private void InitializeActionEffects()
+    {
+        actionEffects = new Dictionary<ActionType, ActionEffect>
+        {
+            // 기본 액션들, 효과(시간, 체력, 평판 순)
+            { ActionType.NotSleep, new ActionEffect(_gameConstants.forcedValue, 0, 0) }, // 8시 강제 기상
+            { ActionType.LessSleep, new ActionEffect(+5.0f, +6.0f, 0) },
+            { ActionType.SleepWell, new ActionEffect(+8.0f, +8.0f, 0) },
+            { ActionType.ForcedSleep, new ActionEffect(+10.0f, +4.0f, 0) },
+            { ActionType.Eat, new ActionEffect(+1.0f, +1.0f, 0) },
+            { ActionType.Work, new ActionEffect(+10.0f, -3.0f, +0.2f) }, // 8to6: 10시간
+            { ActionType.Dungeon, new ActionEffect(+3.0f, -3.0f, 0) },
+            { ActionType.Housework, new ActionEffect(+1.0f, -1.0f, +0.2f) },
+            { ActionType.OvertimeWork, new ActionEffect(+4.0f, -5.0f, +1.0f) },
+            { ActionType.TeamDinner, new ActionEffect(_gameConstants.forcedValue, _gameConstants.forcedValue, 0) }, // 수면 강제(8시 기상) 후 최대 체력
+            { ActionType.Absence, new ActionEffect(0, 0, -3.0f) }
+        };
+    }
+
+    // 액션에 따른 효과(스탯 가감)
+    public ActionEffect GetActionEffect(ActionType actionType)
+    {
+        if (actionEffects.TryGetValue(actionType, out ActionEffect effect))
+        {
+            return effect;
+        }
+        
+        // 없으면 기본값 반환
+        return new ActionEffect(0, 0, 0);
+    }
+}

--- a/Assets/KSH/ValueByAction.cs.meta
+++ b/Assets/KSH/ValueByAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2aa1af61c6712fc45bf458c18cd2c874
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
행동에 따라 스탯(시간, 체력, 평판)이 조정되는 스크립트입니다.
스탯은 float 타입입니다.
체력/평판 최소 스탯: 각각 0
체력/평판 최대 스탯: 각각 10
체력/평판 기본 스탯: 8/5

시간은 24시간제를 사용하고 있습니다.
시간 기본 설정: 오전 8시
시간은 24시가 되면 다음 날로 넘어가며 0으로 초기화 됩니다.
강제 수면(회식 포함)은 잠든 시간과 상관없이 오전 8시에 기상합니다.
그 외 수면 시간은 현재 시간 + 수면 시간 이후로 깨어납니다.
수면과 관련하여 변경이 필요하다면 말씀해주세요

---

# 생성된 스크립트

### ValueByAction.cs
: **행동에 따른 스탯 가중치**를 가지고 있습니다. 
스탯 가중치는 기획서 - 행동 별 사회생활력 증감, 소모 시간 명세 에 기재된 값을 사용하였습니다. 
[기획서 링크](https://www.notion.so/1cf1bb549d3880f8a465ed18f6399370#1cf1bb549d388058bd51e4c7cd086af3)
보너스 스테이지를 제외하고 순서를 똑같이 작성하였으니 참고 바랍니다.
강제 수면과 회식의 경우 현재 시간과 상관없이 다음 날 오전 8시 기상이 강제됩니다.

### PlayerStats.cs
: public 메서드인 PerformAction 을 통해 **행동에 따라 스탯을 조정**합니다. 행동은 ActionType(enum)을 사용해주세요.
또한 체력에 따라 해당 행동이 가능한지 체크하는 메서드를 갖고 있습니다.
사용 예시 playerStats.PerformAction(ActionType.NotSleep); -> 해당 행동에 따라 스탯 조정
CanPerformByHealth(ActionType.Dungeon) -> 해당 행동이 체력적으로 가능한지 여부 판단

### GameConstants.cs (ActionType 포함)
: 행동 타입인 ActionType 을 가지고 있으며, 기본 스탯 값, 최대 스탯 값, 최대 날짜 값(현재는 7일)을 가지고 있습니다.

### GameManager.cs 
: **현재 날짜와 씬 전환을 관리**합니다.
씬 전환은 틀만 만든 상황이며 추후에 Scene이 생성되면 작업할 예정입니다.
날짜는 PlayerStats의 시간에 따라 자동으로 조정됩니다. 
이때 자동으로 조정된다는 것은 PlayerStats의 시간 값이 24와 크거나 같을 때 날짜에 +1을 하는 것을 의미합니다.

### Singleton.cs
: 싱글톤 패턴입니다. GameManager에서 사용하고 있습니다.


---

# 사용 방법
1. 플레이어 오브젝트에게 PlayerStats.cs 할당
2. 빈 게임 오브젝트에 GameManager.cs 할당
3. GameManager.cs 할당된 오브젝트의 SerializeField에 플레이어 오브젝트 - PlayerStats.cs 할당
4. 이후 다른 스크립트(ex. 상호 작용 스크립트)에서 FindObjectOfType<PlayerStats>() 등을 통해 PlayerStats를 찾아 PerformAction을 수행하시면 됩니다.
PlayerStats을 찾으면 스탯 값 Get 또한 가능합니다.

---

# 테스트 방법
KSH/TestCode 의 Test.prefab을 화면에 배치하여 테스트가 가능합니다.
그 외 사용 예시는 KSH/TestCode/PlayerStatsTest.cs 파일에서 확인이 가능합니다.

감사합니다.