### PR TITLE
DEG-110 [FIX] 모션 수정

### DIFF
--- a/Assets/JAY/Animation/UpperBody_Passthrough.anim
+++ b/Assets/JAY/Animation/UpperBody_Passthrough.anim
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1454353b71088e1cf194335868e06e115062d15030a5b00b96b3370bd3261595
+size 1309

--- a/Assets/JAY/Animation/UpperBody_Passthrough.anim.meta
+++ b/Assets/JAY/Animation/UpperBody_Passthrough.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5caba6316080f564091600905868fb66
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/JAY/Animator/PlayerController.controller
+++ b/Assets/JAY/Animator/PlayerController.controller
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c3a3ff387918a08ae9e50522f6f0c415cc09baf0f69809f2dee0a28d72a7fd65
-size 22423
+oid sha256:133f2c5386e1eb7ef1f6b0de157b50f79c31843107cc8d4291a128e3bd1b2a81
+size 20655

--- a/Assets/JAY/HousingUI.unity
+++ b/Assets/JAY/HousingUI.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a163748df40f56fc751a7544b35dd94db65bf2fd32eb7b6eff20ee4defa31190
-size 74027
+oid sha256:55cf84a51994b5762122636fec95fc4053dab6d94394c496ce3dfc5b78d48970
+size 74215


### PR DESCRIPTION
# 캐릭터 움직임 버그 수정

## 이슈
승리, 패배 모션이 덮어씌워져서 move일때 다리 안움직임

## 해결
override layer 하나로 줄이고, upperbodyattack 레이어(상체만 움직임)에 Idle 대신 빈 애니메이션 클립(UpperBody_Passthrough)를 default 레이어로 설정

https://github.com/user-attachments/assets/6841edad-d84f-442c-9844-1a5d0a34b321

