### PR TITLE
Deg 108 던전 체력 구현

### DIFF
--- a/Assets/JAY/Scripts/PlayerController.cs
+++ b/Assets/JAY/Scripts/PlayerController.cs
@@ -70,6 +70,8 @@ public class PlayerController : CharacterBase, IObserver<GameObject>
         _actionDash = new PlayerActionDash();
         
         PlayerInit();
+
+        SwitchBattleMode();
     }
     
     private void Update()
@@ -211,6 +213,16 @@ public class PlayerController : CharacterBase, IObserver<GameObject>
 
     public void OnNext(GameObject value)
     {
+        float playerAttackPower = _weaponController.AttackPower * attackPower;
+        
+        if (value.CompareTag("Enemy")) // 적이 Enemy일 때만 공격 처리
+        {
+            var enemyController = value.transform.GetComponent<EnemyController>();
+            if (enemyController != null)
+            {
+                enemyController.TakeDamage(playerAttackPower);
+            }
+        }
     }
 
     public void OnError(Exception error)

--- a/Assets/JAY/Scripts/PlayerController.cs
+++ b/Assets/JAY/Scripts/PlayerController.cs
@@ -88,6 +88,7 @@ public class PlayerController : CharacterBase, IObserver<GameObject>
         
         // 공격 입력 처리
         if (Input.GetKeyDown(KeyCode.X) && (_currentAction == null || !_currentAction.IsActive)) {
+            Debug.Log("X 버튼 Down 됨");
             StartAttackAction();
         }
         
@@ -171,6 +172,7 @@ public class PlayerController : CharacterBase, IObserver<GameObject>
         if (_weaponController.IsAttacking) return;  // 이미 공격 중이면 실행 안함
 
         if (_currentAction == _attackAction) {
+            Debug.Log($"Attack True");
             _attackAction.EnableCombo();
             _weaponController.AttackStart();
         }
@@ -178,8 +180,10 @@ public class PlayerController : CharacterBase, IObserver<GameObject>
 
     public void SetAttackComboFalse() {
         if (_currentAction == _attackAction) {
+            Debug.Log($"Attack False"); 
+            // 이벤트 중복 호출? 공격 종료 시 SetAttackComboFalse가 아니라 ~True로 끝나서 오류 발생. (공격 안하는 상태여도 공격으로 판정됨)
             _attackAction.DisableCombo();
-            _weaponController.AttackEnd();
+            _weaponController.AttackEnd(); // IsAttacking = false로 변경
         }
     }
 

--- a/Assets/JAY/Scripts/PlayerController.cs
+++ b/Assets/JAY/Scripts/PlayerController.cs
@@ -89,7 +89,8 @@ public class PlayerController : CharacterBase, IObserver<GameObject>
         }
         
         // 공격 입력 처리
-        if (Input.GetKeyDown(KeyCode.X) && (_currentAction == null || !_currentAction.IsActive)) {
+        if (Input.GetKeyDown(KeyCode.X) && (_currentAction == null || !_currentAction.IsActive)
+            && (CurrentState != PlayerState.Win && CurrentState != PlayerState.Dead)) {
             Debug.Log("X 버튼 Down 됨");
             StartAttackAction();
         }

--- a/Assets/JAY/Scripts/WeaponController.cs
+++ b/Assets/JAY/Scripts/WeaponController.cs
@@ -106,7 +106,6 @@ public class WeaponController : MonoBehaviour, IObservable<GameObject>
                     {
                         _hitColliders.Add(hit.collider);
 
-                        Debug.Log("hit.collider.name: " + hit.collider.name);
                         if (hit.collider.gameObject.CompareTag("Enemy"))
                         {
                             var enemyController = hit.transform.GetComponent<EnemyController>();

--- a/Assets/JAY/Scripts/WeaponController.cs
+++ b/Assets/JAY/Scripts/WeaponController.cs
@@ -49,7 +49,11 @@ public class WeaponController : MonoBehaviour, IObservable<GameObject>
         _playerController = GetComponent<PlayerController>();
         if (_playerController == null)
         {
-            _playerController = GameObject.FindGameObjectWithTag("Player").GetComponent<PlayerController>();
+            var player = GameObject.FindGameObjectWithTag("Player");
+            if (player != null)
+            {
+                _playerController = player.GetComponent<PlayerController>();
+            }
         }
         
         _previousPositions = new Vector3[_triggerZones.Length];
@@ -106,7 +110,7 @@ public class WeaponController : MonoBehaviour, IObservable<GameObject>
                         if (hit.collider.gameObject.CompareTag("Enemy"))
                         {
                             var enemyController = hit.transform.GetComponent<EnemyController>();
-                            if (enemyController != null)
+                            if (enemyController != null && _playerController != null)
                             {
                                 enemyController.TakeDamage(AttackPower * _playerController.attackPower);
                             }

--- a/Assets/JAY/Scripts/WeaponController.cs
+++ b/Assets/JAY/Scripts/WeaponController.cs
@@ -69,10 +69,24 @@ public class WeaponController : MonoBehaviour, IObservable<GameObject>
         }
         _isAttacking = true;
         _hitColliders.Clear();
+        
+        StopAllCoroutines();
+        StartCoroutine(AutoEndAttack()); // 자동 공격 종료
 
         for (int i = 0; i < _triggerZones.Length; i++)
         {
             _previousPositions[i] = transform.position + transform.TransformVector(_triggerZones[i].position);
+        }
+    }
+    
+    private IEnumerator AutoEndAttack()
+    {
+        yield return new WaitForSeconds(0.6f); // 0.6초 가량 대기
+    
+        if (_isAttacking)  // 아직 공격 중이면
+        {
+            Debug.Log("공격 자동 종료 - 타임아웃");
+            AttackEnd();
         }
     }
 

--- a/Assets/JAY/Scripts/WeaponController.cs
+++ b/Assets/JAY/Scripts/WeaponController.cs
@@ -105,16 +105,6 @@ public class WeaponController : MonoBehaviour, IObservable<GameObject>
                     if (!_hitColliders.Contains(hit.collider))
                     {
                         _hitColliders.Add(hit.collider);
-
-                        if (hit.collider.gameObject.CompareTag("Enemy"))
-                        {
-                            var enemyController = hit.transform.GetComponent<EnemyController>();
-                            if (enemyController != null && _playerController != null)
-                            {
-                                enemyController.TakeDamage(AttackPower * _playerController.attackPower);
-                            }
-                        }
-                        
                         Notify(hit.collider.gameObject);
                     }
                 }

--- a/Assets/KSH/DungeonLogic.cs
+++ b/Assets/KSH/DungeonLogic.cs
@@ -5,6 +5,8 @@ using UnityEngine;
 
 public class DungeonLogic : MonoBehaviour
 {
+    [SerializeField] private DungeonPanelController _dungeonPanelController;
+    
     [NonSerialized] public bool isCompleted = false;               // 던전 클리어 여부
     [NonSerialized] public bool isFailed = false;                  // 던전 실패 여부
     
@@ -24,19 +26,35 @@ public class DungeonLogic : MonoBehaviour
         // 죽음 이벤트 구독
         if (_player != null)
         {
+            _player.OnGetHit += OnPlayerGetHit;
             _player.OnDeath += OnPlayerDeath;
         }
         
         if (_enemy != null)
         {
+            _enemy.OnGetHit += OnEnemyGetHit;
             _enemy.OnDeath += OnEnemyDeath;
         }
     }
 
-    // 플레이어 사망 처리
-    private void OnPlayerDeath(CharacterBase player)
+    private void OnPlayerGetHit(CharacterBase player)
     {
-        Debug.Log("player name:" + player.characterName);
+        var result = _dungeonPanelController.SetPlayerHealth();
+        if (!result) // 하트 모두 소모
+        {
+            player.Die();
+        }
+    }
+
+    private void OnEnemyGetHit(CharacterBase enemy)
+    {
+        Debug.Log("Enemy HP: " + enemy.currentHP);
+        _dungeonPanelController.SetBossHealthBar(enemy.currentHP);
+    }
+
+    // 플레이어 사망 처리
+    private void OnPlayerDeath()
+    {
         if (!isFailed) // 중복 실행 방지
         {
             FailDungeon();
@@ -44,9 +62,8 @@ public class DungeonLogic : MonoBehaviour
     }
     
     // 적 사망 처리
-    private void OnEnemyDeath(CharacterBase enemy)
+    private void OnEnemyDeath()
     {
-        Debug.Log("enemy name:" + enemy.characterName);
         if (!isCompleted) // 중복 실행 방지
         {
             CompleteDungeon();
@@ -62,7 +79,7 @@ public class DungeonLogic : MonoBehaviour
             isCompleted = true;
             OnDungeonSuccess?.Invoke();
             
-            // 성공 UI 표시 ?? 강화 표기
+            _player.SetState(PlayerState.Win);
             // TODO: 강화 시스템으로 넘어가고 일상 맵으로 이동
         }
     }
@@ -76,10 +93,8 @@ public class DungeonLogic : MonoBehaviour
             isFailed = true;
             OnDungeonFailure?.Invoke();
             
-            // 죽음 애니메이션 + 실패 UI 표시 ?
-            // GameManager.Instance.ChangeToHomeScene();
-            
-            StartCoroutine(DelayedSceneChange()); // 테스트를 위해 3초 대기 후 전환
+            _player.SetState(PlayerState.Dead);
+            StartCoroutine(DelayedSceneChange()); // 3초 대기 후 전환
         }
     }
     

--- a/Assets/KSH/DungeonLogic.cs
+++ b/Assets/KSH/DungeonLogic.cs
@@ -41,6 +41,8 @@ public class DungeonLogic : MonoBehaviour
     {
         if (isFailed || isCompleted) return; // 어느 한 쪽 사망시 더이상 피격 X
         
+        // TODO: 플레이어 피격 효과음
+        
         var result = _dungeonPanelController.SetPlayerHealth();
         if (!result) // 하트 모두 소모
         {
@@ -51,6 +53,8 @@ public class DungeonLogic : MonoBehaviour
     private void OnEnemyGetHit(CharacterBase enemy)
     {
         if (isFailed || isCompleted) return;
+        
+        // TODO: 에너미 피격 효과음
         
         _dungeonPanelController.SetBossHealthBar(enemy.currentHP);
     }

--- a/Assets/KSH/DungeonLogic.cs
+++ b/Assets/KSH/DungeonLogic.cs
@@ -39,6 +39,8 @@ public class DungeonLogic : MonoBehaviour
 
     private void OnPlayerGetHit(CharacterBase player)
     {
+        if (isFailed || isCompleted) return; // 어느 한 쪽 사망시 더이상 피격 X
+        
         var result = _dungeonPanelController.SetPlayerHealth();
         if (!result) // 하트 모두 소모
         {
@@ -48,7 +50,8 @@ public class DungeonLogic : MonoBehaviour
 
     private void OnEnemyGetHit(CharacterBase enemy)
     {
-        Debug.Log("Enemy HP: " + enemy.currentHP);
+        if (isFailed || isCompleted) return;
+        
         _dungeonPanelController.SetBossHealthBar(enemy.currentHP);
     }
 
@@ -78,6 +81,8 @@ public class DungeonLogic : MonoBehaviour
             Debug.Log("던전 공략 성공~!");
             isCompleted = true;
             OnDungeonSuccess?.Invoke();
+
+            _dungeonPanelController.SetBossHealthBar(0.0f); // 보스 체력 0 재설정
             
             _player.SetState(PlayerState.Win);
             // TODO: 강화 시스템으로 넘어가고 일상 맵으로 이동
@@ -94,6 +99,11 @@ public class DungeonLogic : MonoBehaviour
             OnDungeonFailure?.Invoke();
             
             _player.SetState(PlayerState.Dead);
+            
+            // enemy가 더이상 Trace 하지 않도록 처리
+            _player.gameObject.layer = LayerMask.NameToLayer("Ignore Raycast");
+            _enemy.SetState(EnemyState.Idle);
+            
             StartCoroutine(DelayedSceneChange()); // 3초 대기 후 전환
         }
     }

--- a/Assets/KSH/DungeonPanelController.cs
+++ b/Assets/KSH/DungeonPanelController.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class DungeonPanelController : MonoBehaviour
+{
+    [SerializeField] private Slider _bossHealthBar; // 0~1 value
+    [SerializeField] private Image[] _playerHealthImages; // color 값 white / black 로 조정
+    private int _countHealth = 0;
+
+    public void SetBossHealthBar(float hp) // hp: 0~100
+    {
+        float normalizedHp = hp / 100f; // 0~1 사이 값으로 조정
+        _bossHealthBar.value = normalizedHp;
+    }
+
+    // false 반환 시 사망 처리
+    public bool SetPlayerHealth()
+    {
+        if (_countHealth > _playerHealthImages.Length - 1) // out of index error 방지
+        {
+            return false;
+        }
+        
+        _playerHealthImages[_countHealth].color = Color.black;
+        _countHealth++;
+        return _countHealth <= _playerHealthImages.Length - 1;
+    }
+}

--- a/Assets/KSH/DungeonPanelController.cs
+++ b/Assets/KSH/DungeonPanelController.cs
@@ -19,6 +19,8 @@ public class DungeonPanelController : MonoBehaviour
     // false 반환 시 사망 처리
     public bool SetPlayerHealth()
     {
+        StartCoroutine(WaitForOneSecond());
+        
         if (_countHealth > _playerHealthImages.Length - 1) // out of index error 방지
         {
             return false;
@@ -27,5 +29,10 @@ public class DungeonPanelController : MonoBehaviour
         _playerHealthImages[_countHealth].color = Color.black;
         _countHealth++;
         return _countHealth <= _playerHealthImages.Length - 1;
+    }
+    
+    IEnumerator WaitForOneSecond()
+    {
+        yield return new WaitForSeconds(1.0f);
     }
 }

--- a/Assets/KSH/DungeonPanelController.cs
+++ b/Assets/KSH/DungeonPanelController.cs
@@ -20,11 +20,8 @@ public class DungeonPanelController : MonoBehaviour
     public bool SetPlayerHealth()
     {
         StartCoroutine(WaitForOneSecond());
-        
-        if (_countHealth > _playerHealthImages.Length - 1) // out of index error 방지
-        {
-            return false;
-        }
+        // out of index error 방지
+        if (_countHealth > _playerHealthImages.Length - 1) return false;
         
         _playerHealthImages[_countHealth].color = Color.black;
         _countHealth++;

--- a/Assets/KSH/DungeonPanelController.cs.meta
+++ b/Assets/KSH/DungeonPanelController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75caf6a3958eb0745a00749003e12d73
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KSH/DungeonTestScene.unity
+++ b/Assets/KSH/DungeonTestScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ee7536d36b114bd9488ea8f43600194c288f7bb6a77bbb0ba1247b8486a6dd78
+oid sha256:7b994f0db1a78d57442ff714bbde098d085ed1ac985def8e2890bcee787c2d72
 size 236615

--- a/Assets/KSH/DungeonTestScene.unity
+++ b/Assets/KSH/DungeonTestScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a3f988deb686f35d4ca0aeb90dcf4d726ccff34a27d1b5f0e020b0ceeb008606
-size 185731
+oid sha256:ee7536d36b114bd9488ea8f43600194c288f7bb6a77bbb0ba1247b8486a6dd78
+size 236615

--- a/Assets/Scripts/Character/CharacterBase.cs
+++ b/Assets/Scripts/Character/CharacterBase.cs
@@ -28,6 +28,8 @@ public abstract class CharacterBase : MonoBehaviour
 
     public virtual void TakeDamage(float damage)
     {
+        if (currentHP <= 0) return;
+        
         float actualDamage = Mathf.Max(0, damage - defensePower);
         currentHP -= Mathf.RoundToInt(actualDamage);
         Debug.Log($"{characterName}이 {actualDamage}의 피해를 입었습니다. 현재 체력: {currentHP}");
@@ -35,6 +37,7 @@ public abstract class CharacterBase : MonoBehaviour
         if (currentHP <= 0)
         {
             Die();
+            return;
         }
         
         OnGetHit?.Invoke(this);

--- a/Assets/Scripts/Character/CharacterBase.cs
+++ b/Assets/Scripts/Character/CharacterBase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -17,7 +18,8 @@ public abstract class CharacterBase : MonoBehaviour
     [Header("상태 이상")]
     public List<StatusEffect> statusEffects = new List<StatusEffect>();
     
-    public event System.Action<CharacterBase> OnDeath; // 사망 이벤트
+    public event Action OnDeath; // 사망 이벤트
+    public event Action<CharacterBase> OnGetHit; // 피격 이벤트
 
     protected virtual void Start()
     {
@@ -34,13 +36,15 @@ public abstract class CharacterBase : MonoBehaviour
         {
             Die();
         }
+        
+        OnGetHit?.Invoke(this);
     }
 
     public virtual void Die()
     {
         Debug.Log($"{characterName}이 사망했습니다.");
         // TODO: 사망 처리
-        OnDeath?.Invoke(this);
+        OnDeath?.Invoke();
     }
 
     // 상태이상 추가 메서드


### PR DESCRIPTION
**던전내의 체력을 UI와 연동 및 공격 처리 수정**

---

## 변경 사항
1. 플레이어 공격 입력 제한
    - 현재 상태가 Win 혹은 Dead 일 시 공격 처리 X

2. 자동 공격 종료 추가
    - 공격 이후 0.6초의 대기 시간 이후 자동으로 공격을 중지시킵니다.
      - 기존: 공격 종료 후 _isAttacking = true 로 남아 공격으로 판단 및 동작됨
      - 변경: 공격 종료 후 대기 시간이 지나면_isAttacking = false로 전환
    - 테스트를 통해 공격 종료(SetAttackComboFalse()) 함수가 동작하지 않았을 때에만 강제 종료됨을 확인

3. 플레이어/에너미 체력을 던전 UI 체력바와 연동 
    - 플레이어는 하트 3칸의 체력을 가지며, 하트 3개가 모두 어둡게 되었을 때 사망 처리가 됩니다. (3번 맞을 시 사망)
      - 구현을 위해 피격 이벤트 추가
    - 플레이어/에너미 중 하나가 사망했을 경우 피격 이벤트는 더 이상 발생하지 않습니다.
      - 아래의 영상을 통해 에너미가 죽은 이후 남은 공격에 맞아도 플레이어의 피가 닳지 않음을 확인 가능.
      - 해당 부분에 수정이 필요하면 말씀해주시기 바랍니다.

## 테스트 영상

https://github.com/user-attachments/assets/b53ba9d0-0b41-44dd-87d0-1341373fb0c0


## 추후 수정 사항
1. 애니메이션 중복 호출 방지 처리



테스트는 KSH/DungeonTestScene 에서 가능합니다.